### PR TITLE
feat: gate Progress tab Studio link on MFE_CONFIG.ENABLE_PROGRESS_TAB_STUDIO_LINK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased] - 2026-04-16
+
+### Added
+- **Progress tab "View in Studio" link now gated by `MFE_CONFIG.ENABLE_PROGRESS_TAB_STUDIO_LINK`** — the admin-only Studio link in `src/course-home/progress-tab/ProgressHeader.jsx` previously rendered for any user whose auth payload carried `administrator: true`. It now also requires the deployment flag `ENABLE_PROGRESS_TAB_STUDIO_LINK` (boolean `true` or string `'true'`) to be set via `MFE_CONFIG` / `/api/mfe_config/v1`. Default is off, so the button stays hidden until a deployment opts in. Paired with the `iblai-cli-ops` 5.7.0 tutor plugin change that emits this flag from `IBL_EDX.MFE_CONFIG.ENABLE_PROGRESS_TAB_STUDIO_LINK`.
+
 ## [Unreleased] - 2026-02-02
 
 ### Fixed

--- a/src/course-home/progress-tab/ProgressHeader.jsx
+++ b/src/course-home/progress-tab/ProgressHeader.jsx
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
@@ -35,10 +36,13 @@ const ProgressHeader = () => {
     ? intl.formatMessage(messages.progressHeaderForTargetUser, { username })
     : intl.formatMessage(messages.progressHeader);
 
+  const studioLinkFlag = getConfig().ENABLE_PROGRESS_TAB_STUDIO_LINK;
+  const showStudioLink = studioLinkFlag === true || studioLinkFlag === 'true';
+
   return (
     <div className="row w-100 m-0 mt-3 mb-4 justify-content-between">
       <h1>{pageTitle}</h1>
-      {administrator && studioUrl && (
+      {showStudioLink && administrator && studioUrl && (
       <Button variant="outline-primary" size="sm" className="align-self-center" href={studioUrl}>
         {intl.formatMessage(messages.studioLink)}
       </Button>


### PR DESCRIPTION
## Summary
- Gate the admin-only "View in Studio" button on the learner Progress tab (`src/course-home/progress-tab/ProgressHeader.jsx`) behind a new MFE config flag `ENABLE_PROGRESS_TAB_STUDIO_LINK`.
- The button previously rendered for any user with `administrator: true` on their auth payload. It now also requires the deployment flag (boolean `true` or string `'true'`) coming from `MFE_CONFIG` / `/api/mfe_config/v1`.
- Default behavior: button is hidden. Deployments opt in by setting the flag.
- Updated `CHANGELOG.md` with a `2026-04-16` unreleased entry. `package.json` version is managed by semantic-release, not manually bumped.

## Why
Deployments were masking the button with a CSS selector (`a.btn.btn-outline-primary.btn-sm[href*="/settings/grading/course-v1:"]`). Replacing the CSS hack with a real feature flag gives a clean per-node switch instead of cosmetic hiding.

## Pairs with
- iblai-cli-ops 5.7.0 PR: https://github.com/iblai/iblai-cli-ops/pull/1939

## Test plan
- [ ] With `ENABLE_PROGRESS_TAB_STUDIO_LINK` unset or `false`, administrator user visits Progress tab → no "View in Studio" button.
- [ ] With `ENABLE_PROGRESS_TAB_STUDIO_LINK: true`, administrator user visits Progress tab → button renders with correct `studioUrl`.
- [ ] Non-administrator user never sees the button regardless of flag state.
- [ ] Verify flag accepts both boolean `true` and string `'true'` (different MFE config injection paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)